### PR TITLE
Transaction Pool Feed

### DIFF
--- a/TXPOOL-FEEDS.md
+++ b/TXPOOL-FEEDS.md
@@ -1,0 +1,110 @@
+## Transaction Pool Feeds
+
+This fork of Geth includes two new types of subscriptions, available through the
+eth_subscribe method on Websockets.
+
+### Rejected Transactions
+
+Using Websockets, you can subscribe to a feed of rejected transactions with:
+
+```
+{"id": 0, "method": "eth_subscribe", "params":["rejectedTransactions"]}
+```
+
+This will immediately return a payload of the form:
+
+```
+{"jsonrpc":"2.0","id":0,"result":"$SUBSCRIPTION_ID"}
+```
+
+And as messages are rejected by the transaction pool, it will send additional
+messages of the form:
+
+```
+{
+  "jsonrpc": "2.0",
+  "method": "eth_subscription",
+  "params": {
+    "subscription": "$SUBSCRIPTION_ID",
+    "result": {
+      "tx": "$ETHEREUM_TRANSACTION",
+      "reason": "$REJECT_REASON"
+    }
+  }
+}
+```
+
+One message will be emitted on this feed for every transaction rejected by the
+transaction pool, excluding those rejected because they were already known by
+the transaction pool.
+
+It is important that consuming applications process messages quickly enough to
+keep up with the process. Geth will buffer up to 20,000 messages, but if that
+threshold is reached the subscription will be discarded by the server.
+
+The reject reason corresponds to the error messages returned by Geth within the
+txpool. At the time of this writing, these include:
+
+* invalid sender
+* nonce too low
+* transaction underpriced
+* replacement transaction underpriced
+* insufficient funds for gas * price + value
+* intrinsic gas too low
+* exceeds block gas limit
+* negative value
+* oversized data
+
+However it is possible that in the future Geth may add new error types that
+could be included by this response without modification to the rejection feed
+itself.
+
+## Dropped Transactions
+
+Using Websockets, you can subscribe to a feed of dropped transaction hashes with:
+
+```
+{"id": 0, "method": "eth_subscribe", "params":["droppedTransactions"]}
+```
+
+This will immediately return a payload of the form:
+
+```
+{"jsonrpc":"2.0","id":0,"result":"$SUBSCRIPTION_ID"}
+```
+
+And as messages are dropped from the transaction pool, it will send additional
+messages of the form:
+
+```
+{
+  "jsonrpc": "2.0",
+  "method": "eth_subscription",
+  "params": {
+    "subscription": "0xe5fa5d3c8ec05953bd746a784cfeade6",
+    "result": {
+      "txhash": "$TRANSACTION_HASH",
+      "reason": "$REASON"
+    }
+  }
+}
+```
+
+One message will be emitted on this feed for every transaction dropped from the
+transaction pool.
+
+It is important that consuming applications process messages quickly enough to
+keep up with the process. Geth will buffer up to 20,000 messages, but if that
+threshold is reached the subscription will be discarded by the server.
+
+The following reasons may be included as reasons transactions were rejected:
+
+* underpriced-txs: Indicates the transaction's gas price is below the node's threshold.
+* low-nonce-txs: Indicates that the account nonce for the sender of this transaction has exceeded the nonce on this transction. That may happen when this transaction is included in a block, or when a replacement transaction is included in a block.
+* unpayable-txs: Indicates that the sender lacks sufficient funds to pay the intrinsic gas for this transaction
+* account-cap-txs: Indicates that this account has sent enough transactions to exceed the per-account limit on the node.
+* replaced-txs: Indicates that the transaction was dropped because a replacement transaction with the same nonce and higher gas has replaced it.
+* unexecutable-txs: Indicates that a transaction is no longer considered executable. This typically applies to queued transaction, when a dependent pending transaction was removed for a reason such as unpayable-txs.
+* truncating-txs: The transaction was dropped because the number of transactions in the mempool exceeds the allowable limit.
+* old-txs: The transaction was dropped because it has been in the mempool longer than the allowable period of time without inclusion in a block.
+* updated-gas-price: The node's minimum gas price was updated, and transactions below that price were dropped.

--- a/accounts/abi/bind/backends/dropped_tx_subscription.go
+++ b/accounts/abi/bind/backends/dropped_tx_subscription.go
@@ -1,0 +1,16 @@
+package backends
+
+
+import (
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+
+func (fb *filterBackend) SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) event.Subscription {
+	return nullSubscription()
+}
+
+func (fb *filterBackend) SubscribeRejectedTxEvent(ch chan<- core.RejectedTxEvent) event.Subscription {
+	return nullSubscription()
+}

--- a/core/events.go
+++ b/core/events.go
@@ -24,6 +24,18 @@ import (
 // NewTxsEvent is posted when a batch of transactions enter the transaction pool.
 type NewTxsEvent struct{ Txs []*types.Transaction }
 
+// DropTxsEvent is posted when a batch of transactions are removed from the transaction pool
+type DropTxsEvent struct{
+	Txs []*types.Transaction
+	Reason string
+}
+
+// RejectedTxsEvent is posted when a batch of transactions are removed from the transaction pool
+type RejectedTxsEvent struct{
+	Txs []*types.Transaction
+	Reason string
+}
+
 // NewMinedBlockEvent is posted when a block has been imported.
 type NewMinedBlockEvent struct{ Block *types.Block }
 
@@ -41,3 +53,17 @@ type ChainSideEvent struct {
 }
 
 type ChainHeadEvent struct{ Block *types.Block }
+
+
+const (
+	dropUnderpriced = "underpriced-txs"
+	dropLowNonce = "low-nonce-txs"
+	dropUnpayable = "unpayable-txs"
+
+	dropAccountCap = "account-cap-txs" // Accounts exceeding txpool.accountslots transactions
+	dropReplaced = "replaced-txs"
+	dropUnexecutable = "unexecutable-txs"
+	dropTruncating = "truncating-txs"
+	dropOld = "old-txs"
+	dropGasPriceUpdated = "updated-gas-price"
+)

--- a/core/events.go
+++ b/core/events.go
@@ -30,10 +30,10 @@ type DropTxsEvent struct{
 	Reason string
 }
 
-// RejectedTxsEvent is posted when a batch of transactions are removed from the transaction pool
-type RejectedTxsEvent struct{
-	Txs []*types.Transaction
-	Reason string
+// RejectedTxEvent is posted when a transaction is rejected from entering the transaction pool
+type RejectedTxEvent struct{
+	Tx *types.Transaction
+	Reason error
 }
 
 // NewMinedBlockEvent is posted when a block has been imported.

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -428,9 +428,9 @@ func (pool *TxPool) SubscribeDropTxsEvent(ch chan<- DropTxsEvent) event.Subscrip
 	return pool.scope.Track(pool.dropTxFeed.Subscribe(ch))
 }
 
-// SubscribeRejectedTxsEvent registers a subscription of RejectedTxEvent and
+// SubscribeRejectedTxEvent registers a subscription of RejectedTxEvent and
 // starts sending event to the given channel.
-func (pool *TxPool) SubscribeRejectedTxsEvent(ch chan<- RejectedTxEvent) event.Subscription {
+func (pool *TxPool) SubscribeRejectedTxEvent(ch chan<- RejectedTxEvent) event.Subscription {
 	return pool.scope.Track(pool.rejectTxFeed.Subscribe(ch))
 }
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -225,14 +225,16 @@ func (config *TxPoolConfig) sanitize() TxPoolConfig {
 // current state) and future transactions. Transactions move between those
 // two states over time as they are received and processed.
 type TxPool struct {
-	config      TxPoolConfig
-	chainconfig *params.ChainConfig
-	chain       blockChain
-	gasPrice    *big.Int
-	txFeed      event.Feed
-	scope       event.SubscriptionScope
-	signer      types.Signer
-	mu          sync.RWMutex
+	config       TxPoolConfig
+	chainconfig  *params.ChainConfig
+	chain        blockChain
+	gasPrice     *big.Int
+	txFeed       event.Feed
+	dropTxFeed   event.Feed
+	rejectTxFeed event.Feed
+	scope        event.SubscriptionScope
+	signer       types.Signer
+	mu           sync.RWMutex
 
 	istanbul bool // Fork indicator whether we are in the istanbul stage.
 
@@ -374,9 +376,14 @@ func (pool *TxPool) loop() {
 				}
 				// Any non-locals old enough should be removed
 				if time.Since(pool.beats[addr]) > pool.config.Lifetime {
-					for _, tx := range pool.queue[addr].Flatten() {
+					txs := pool.queue[addr].Flatten()
+					for _, tx := range txs {
 						pool.removeTx(tx.Hash(), true)
 					}
+					pool.dropTxFeed.Send(DropTxsEvent{
+						Txs: txs,
+						Reason: dropOld,
+					})
 				}
 			}
 			pool.mu.Unlock()
@@ -415,6 +422,18 @@ func (pool *TxPool) SubscribeNewTxsEvent(ch chan<- NewTxsEvent) event.Subscripti
 	return pool.scope.Track(pool.txFeed.Subscribe(ch))
 }
 
+// SubscribeDropTxsEvent registers a subscription of DropTxsEvent and
+// starts sending event to the given channel.
+func (pool *TxPool) SubscribeDropTxsEvent(ch chan<- DropTxsEvent) event.Subscription {
+	return pool.scope.Track(pool.dropTxFeed.Subscribe(ch))
+}
+
+// SubscribeRejectedTxsEvent registers a subscription of RejectedTxsEvent and
+// starts sending event to the given channel.
+func (pool *TxPool) SubscribeRejectedTxsEvent(ch chan<- RejectedTxsEvent) event.Subscription {
+	return pool.scope.Track(pool.rejectTxFeed.Subscribe(ch))
+}
+
 // GasPrice returns the current gas price enforced by the transaction pool.
 func (pool *TxPool) GasPrice() *big.Int {
 	pool.mu.RLock()
@@ -430,9 +449,14 @@ func (pool *TxPool) SetGasPrice(price *big.Int) {
 	defer pool.mu.Unlock()
 
 	pool.gasPrice = price
-	for _, tx := range pool.priced.Cap(price, pool.locals) {
+	txs := pool.priced.Cap(price, pool.locals)
+	for _, tx := range txs {
 		pool.removeTx(tx.Hash(), false)
 	}
+	pool.dropTxFeed.Send(DropTxsEvent{
+		Txs: txs,
+		Reason: dropGasPriceUpdated,
+	})
 	log.Info("Transaction pool price threshold updated", "price", price)
 }
 
@@ -605,6 +629,10 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 			underpricedTxMeter.Mark(1)
 			pool.removeTx(tx.Hash(), false)
 		}
+		pool.dropTxFeed.Send(DropTxsEvent{
+			Txs: drop,
+			Reason: dropUnderpriced,
+		})
 	}
 	// Try to replace an existing transaction in the pending pool
 	from, _ := types.Sender(pool.signer, tx) // already validated
@@ -620,6 +648,10 @@ func (pool *TxPool) add(tx *types.Transaction, local bool) (replaced bool, err e
 			pool.all.Remove(old.Hash())
 			pool.priced.Removed(1)
 			pendingReplaceMeter.Mark(1)
+			pool.dropTxFeed.Send(DropTxsEvent{
+				Txs: []*types.Transaction{old},
+				Reason: dropReplaced,
+			})
 		}
 		pool.all.Add(tx)
 		pool.priced.Put(tx)
@@ -669,6 +701,10 @@ func (pool *TxPool) enqueueTx(hash common.Hash, tx *types.Transaction) (bool, er
 		pool.all.Remove(old.Hash())
 		pool.priced.Removed(1)
 		queuedReplaceMeter.Mark(1)
+		pool.dropTxFeed.Send(DropTxsEvent{
+			Txs: []*types.Transaction{old},
+			Reason: dropReplaced,
+		})
 	} else {
 		// Nothing was replaced, bump the queued counter
 		queuedGauge.Inc(1)
@@ -718,6 +754,10 @@ func (pool *TxPool) promoteTx(addr common.Address, hash common.Hash, tx *types.T
 		pool.priced.Removed(1)
 
 		pendingReplaceMeter.Mark(1)
+		pool.dropTxFeed.Send(DropTxsEvent{
+			Txs: []*types.Transaction{old},
+			Reason: dropReplaced,
+		})
 	} else {
 		// Nothing was replaced, bump the pending counter
 		pendingGauge.Inc(1)
@@ -907,6 +947,10 @@ func (pool *TxPool) removeTx(hash common.Hash, outofbound bool) {
 			pool.pendingNonces.setIfLower(addr, tx.Nonce())
 			// Reduce the pending counter
 			pendingGauge.Dec(int64(1 + len(invalids)))
+			pool.dropTxFeed.Send(DropTxsEvent{
+				Txs: invalids,
+				Reason: dropUnexecutable,
+			})
 			return
 		}
 	}
@@ -1194,6 +1238,10 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 			pool.all.Remove(hash)
 			log.Trace("Removed old queued transaction", "hash", hash)
 		}
+		pool.dropTxFeed.Send(DropTxsEvent{
+			Txs: forwards,
+			Reason: dropLowNonce,
+		})
 		// Drop all transactions that are too costly (low balance or out of gas)
 		drops, _ := list.Filter(pool.currentState.GetBalance(addr), pool.currentMaxGas)
 		for _, tx := range drops {
@@ -1202,6 +1250,10 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 			log.Trace("Removed unpayable queued transaction", "hash", hash)
 		}
 		queuedNofundsMeter.Mark(int64(len(drops)))
+		pool.dropTxFeed.Send(DropTxsEvent{
+			Txs: drops,
+			Reason: dropUnpayable,
+		})
 
 		// Gather all executable transactions and promote them
 		readies := list.Ready(pool.pendingNonces.get(addr))
@@ -1224,6 +1276,10 @@ func (pool *TxPool) promoteExecutables(accounts []common.Address) []*types.Trans
 				log.Trace("Removed cap-exceeding queued transaction", "hash", hash)
 			}
 			queuedRateLimitMeter.Mark(int64(len(caps)))
+			pool.dropTxFeed.Send(DropTxsEvent{
+				Txs: caps,
+				Reason: dropAccountCap,
+			})
 		}
 		// Mark all the items dropped as removed
 		pool.priced.Removed(len(forwards) + len(drops) + len(caps))
@@ -1287,6 +1343,10 @@ func (pool *TxPool) truncatePending() {
 						pool.pendingNonces.setIfLower(offenders[i], tx.Nonce())
 						log.Trace("Removed fairness-exceeding pending transaction", "hash", hash)
 					}
+					pool.dropTxFeed.Send(DropTxsEvent{
+						Txs: caps,
+						Reason: dropAccountCap,
+					})
 					pool.priced.Removed(len(caps))
 					pendingGauge.Dec(int64(len(caps)))
 					if pool.locals.contains(offenders[i]) {
@@ -1314,6 +1374,10 @@ func (pool *TxPool) truncatePending() {
 					pool.pendingNonces.setIfLower(addr, tx.Nonce())
 					log.Trace("Removed fairness-exceeding pending transaction", "hash", hash)
 				}
+				pool.dropTxFeed.Send(DropTxsEvent{
+					Txs: caps,
+					Reason: dropAccountCap,
+				})
 				pool.priced.Removed(len(caps))
 				pendingGauge.Dec(int64(len(caps)))
 				if pool.locals.contains(addr) {
@@ -1354,9 +1418,14 @@ func (pool *TxPool) truncateQueue() {
 
 		// Drop all transactions if they are less than the overflow
 		if size := uint64(list.Len()); size <= drop {
-			for _, tx := range list.Flatten() {
+			txs := list.Flatten()
+			for _, tx := range txs {
 				pool.removeTx(tx.Hash(), true)
 			}
+			pool.dropTxFeed.Send(DropTxsEvent{
+				Txs: txs,
+				Reason: dropTruncating,
+			})
 			drop -= size
 			queuedRateLimitMeter.Mark(int64(size))
 			continue
@@ -1367,6 +1436,10 @@ func (pool *TxPool) truncateQueue() {
 			pool.removeTx(txs[i].Hash(), true)
 			drop--
 			queuedRateLimitMeter.Mark(1)
+			pool.dropTxFeed.Send(DropTxsEvent{
+				Txs: []*types.Transaction{txs[i]},
+				Reason: dropTruncating,
+			})
 		}
 	}
 }
@@ -1386,6 +1459,10 @@ func (pool *TxPool) demoteUnexecutables() {
 			pool.all.Remove(hash)
 			log.Trace("Removed old pending transaction", "hash", hash)
 		}
+		pool.dropTxFeed.Send(DropTxsEvent{
+			Txs: olds,
+			Reason: dropLowNonce,
+		})
 		// Drop all transactions that are too costly (low balance or out of gas), and queue any invalids back for later
 		drops, invalids := list.Filter(pool.currentState.GetBalance(addr), pool.currentMaxGas)
 		for _, tx := range drops {
@@ -1393,6 +1470,10 @@ func (pool *TxPool) demoteUnexecutables() {
 			log.Trace("Removed unpayable pending transaction", "hash", hash)
 			pool.all.Remove(hash)
 		}
+		pool.dropTxFeed.Send(DropTxsEvent{
+			Txs: drops,
+			Reason: dropUnpayable,
+		})
 		pool.priced.Removed(len(olds) + len(drops))
 		pendingNofundsMeter.Mark(int64(len(drops)))
 

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -428,9 +428,9 @@ func (pool *TxPool) SubscribeDropTxsEvent(ch chan<- DropTxsEvent) event.Subscrip
 	return pool.scope.Track(pool.dropTxFeed.Subscribe(ch))
 }
 
-// SubscribeRejectedTxsEvent registers a subscription of RejectedTxsEvent and
+// SubscribeRejectedTxsEvent registers a subscription of RejectedTxEvent and
 // starts sending event to the given channel.
-func (pool *TxPool) SubscribeRejectedTxsEvent(ch chan<- RejectedTxsEvent) event.Subscription {
+func (pool *TxPool) SubscribeRejectedTxsEvent(ch chan<- RejectedTxEvent) event.Subscription {
 	return pool.scope.Track(pool.rejectTxFeed.Subscribe(ch))
 }
 
@@ -853,6 +853,10 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 		for errs[nilSlot] != nil {
 			nilSlot++
 		}
+		pool.rejectTxFeed.Send(RejectedTxEvent{
+			Tx: txs[nilSlot],
+			Reason: err,
+		})
 		errs[nilSlot] = err
 	}
 	// Reorg the pool internals if needed and return

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -853,10 +853,12 @@ func (pool *TxPool) addTxs(txs []*types.Transaction, local, sync bool) []error {
 		for errs[nilSlot] != nil {
 			nilSlot++
 		}
-		pool.rejectTxFeed.Send(RejectedTxEvent{
-			Tx: txs[nilSlot],
-			Reason: err,
-		})
+		if err != nil {
+			pool.rejectTxFeed.Send(RejectedTxEvent{
+				Tx: txs[nilSlot],
+				Reason: err,
+			})
+		}
 		errs[nilSlot] = err
 	}
 	// Reorg the pool internals if needed and return

--- a/core/tx_pool_test.go
+++ b/core/tx_pool_test.go
@@ -152,6 +152,55 @@ func validateEvents(events chan NewTxsEvent, count int) error {
 	return nil
 }
 
+// validateDroppedEvents checks that the correct number of transaction rejection
+// and drop events were fired.
+func validateDroppedEvents(reject chan RejectedTxEvent, rcount int, dropped chan DropTxsEvent, dcount int) error {
+	count := 0
+	for count < rcount {
+		select {
+		case <-reject:
+			count++
+		case <-time.After(time.Second):
+			return fmt.Errorf("reject event #%d not fired", count)
+		}
+	}
+	rloop:
+	for {
+		select {
+		case <-reject:
+			count++
+		case <-time.After(50 * time.Millisecond):
+			break rloop
+		}
+	}
+	if count > rcount {
+		return fmt.Errorf("more than %v reject events fired: %v", rcount, count)
+	}
+	count = 0
+	for count < dcount {
+		select {
+		case <-dropped:
+			count++
+		case <-time.After(time.Second):
+			return fmt.Errorf("drop event #%d not fired", count)
+		}
+	}
+	dloop:
+	for {
+		select {
+		case <-dropped:
+			count++
+		case <-time.After(50 * time.Millisecond):
+			break dloop
+		}
+	}
+	if count > dcount {
+		return fmt.Errorf("more than %v drop events fired: %v", dcount, count)
+	}
+
+	return nil
+}
+
 func deriveSender(tx *types.Transaction) (common.Address, error) {
 	return types.Sender(types.HomesteadSigner{}, tx)
 }
@@ -689,6 +738,12 @@ func TestTransactionGapFilling(t *testing.T) {
 	events := make(chan NewTxsEvent, testTxPoolConfig.AccountQueue+5)
 	sub := pool.txFeed.Subscribe(events)
 	defer sub.Unsubscribe()
+	revents := make(chan RejectedTxEvent, testTxPoolConfig.AccountQueue+5)
+	rsub := pool.rejectTxFeed.Subscribe(revents)
+	defer rsub.Unsubscribe()
+	devents := make(chan DropTxsEvent, testTxPoolConfig.AccountQueue+5)
+	dsub := pool.dropTxFeed.Subscribe(devents)
+	defer dsub.Unsubscribe()
 
 	// Create a pending and a queued transaction with a nonce-gap in between
 	pool.AddRemotesSync([]*types.Transaction{
@@ -721,6 +776,9 @@ func TestTransactionGapFilling(t *testing.T) {
 	}
 	if err := validateEvents(events, 2); err != nil {
 		t.Fatalf("gap-filling event firing failed: %v", err)
+	}
+	if err := validateDroppedEvents(revents, 0, devents, 6); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
 	}
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
@@ -1201,6 +1259,12 @@ func TestTransactionPoolRepricing(t *testing.T) {
 	if err := validateEvents(events, 7); err != nil {
 		t.Fatalf("original event firing failed: %v", err)
 	}
+	revents := make(chan RejectedTxEvent, testTxPoolConfig.AccountQueue+5)
+	rsub := pool.rejectTxFeed.Subscribe(revents)
+	defer rsub.Unsubscribe()
+	devents := make(chan DropTxsEvent, testTxPoolConfig.AccountQueue+5)
+	dsub := pool.dropTxFeed.Subscribe(devents)
+	defer dsub.Unsubscribe()
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
@@ -1216,6 +1280,9 @@ func TestTransactionPoolRepricing(t *testing.T) {
 	}
 	if err := validateEvents(events, 0); err != nil {
 		t.Fatalf("reprice event firing failed: %v", err)
+	}
+	if err := validateDroppedEvents(revents, 0, devents, 3); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
 	}
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
@@ -1233,6 +1300,9 @@ func TestTransactionPoolRepricing(t *testing.T) {
 	if err := validateEvents(events, 0); err != nil {
 		t.Fatalf("post-reprice event firing failed: %v", err)
 	}
+	if err := validateDroppedEvents(revents, 3, devents, 0); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
+	}
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
@@ -1246,6 +1316,9 @@ func TestTransactionPoolRepricing(t *testing.T) {
 	}
 	if err := validateEvents(events, 1); err != nil {
 		t.Fatalf("post-reprice local event firing failed: %v", err)
+	}
+	if err := validateDroppedEvents(revents, 0, devents, 2); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
 	}
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
@@ -1262,6 +1335,9 @@ func TestTransactionPoolRepricing(t *testing.T) {
 	}
 	if err := validateEvents(events, 5); err != nil {
 		t.Fatalf("post-reprice event firing failed: %v", err)
+	}
+	if err := validateDroppedEvents(revents, 0, devents, 9); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
 	}
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
@@ -1350,6 +1426,12 @@ func TestTransactionPoolUnderpricing(t *testing.T) {
 	events := make(chan NewTxsEvent, 32)
 	sub := pool.txFeed.Subscribe(events)
 	defer sub.Unsubscribe()
+	revents := make(chan RejectedTxEvent, testTxPoolConfig.AccountQueue+5)
+	rsub := pool.rejectTxFeed.Subscribe(revents)
+	defer rsub.Unsubscribe()
+	devents := make(chan DropTxsEvent, testTxPoolConfig.AccountQueue+5)
+	dsub := pool.dropTxFeed.Subscribe(devents)
+	defer dsub.Unsubscribe()
 
 	// Create a number of test accounts and fund them
 	keys := make([]*ecdsa.PrivateKey, 4)
@@ -1381,6 +1463,9 @@ func TestTransactionPoolUnderpricing(t *testing.T) {
 	if err := validateEvents(events, 3); err != nil {
 		t.Fatalf("original event firing failed: %v", err)
 	}
+	if err := validateDroppedEvents(revents, 0, devents, 8); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
+	}
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
@@ -1408,6 +1493,9 @@ func TestTransactionPoolUnderpricing(t *testing.T) {
 	if err := validateEvents(events, 1); err != nil {
 		t.Fatalf("additional event firing failed: %v", err)
 	}
+	if err := validateDroppedEvents(revents, 1, devents, 13); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
+	}
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
@@ -1429,6 +1517,9 @@ func TestTransactionPoolUnderpricing(t *testing.T) {
 	}
 	if err := validateEvents(events, 2); err != nil {
 		t.Fatalf("local event firing failed: %v", err)
+	}
+	if err := validateDroppedEvents(revents, 0, devents, 7); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
 	}
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
@@ -1456,6 +1547,12 @@ func TestTransactionPoolStableUnderpricing(t *testing.T) {
 	events := make(chan NewTxsEvent, 32)
 	sub := pool.txFeed.Subscribe(events)
 	defer sub.Unsubscribe()
+	revents := make(chan RejectedTxEvent, testTxPoolConfig.AccountQueue+5)
+	rsub := pool.rejectTxFeed.Subscribe(revents)
+	defer rsub.Unsubscribe()
+	devents := make(chan DropTxsEvent, testTxPoolConfig.AccountQueue+5)
+	dsub := pool.dropTxFeed.Subscribe(devents)
+	defer dsub.Unsubscribe()
 
 	// Create a number of test accounts and fund them
 	keys := make([]*ecdsa.PrivateKey, 2)
@@ -1480,6 +1577,9 @@ func TestTransactionPoolStableUnderpricing(t *testing.T) {
 	if err := validateEvents(events, int(config.GlobalSlots)); err != nil {
 		t.Fatalf("original event firing failed: %v", err)
 	}
+	if err := validateDroppedEvents(revents, 0, devents, 3); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
+	}
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
 	}
@@ -1496,6 +1596,9 @@ func TestTransactionPoolStableUnderpricing(t *testing.T) {
 	}
 	if err := validateEvents(events, 1); err != nil {
 		t.Fatalf("additional event firing failed: %v", err)
+	}
+	if err := validateDroppedEvents(revents, 0, devents, 4); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
 	}
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)
@@ -1583,6 +1686,12 @@ func TestTransactionReplacement(t *testing.T) {
 	events := make(chan NewTxsEvent, 32)
 	sub := pool.txFeed.Subscribe(events)
 	defer sub.Unsubscribe()
+	revents := make(chan RejectedTxEvent, testTxPoolConfig.AccountQueue+5)
+	rsub := pool.rejectTxFeed.Subscribe(revents)
+	defer rsub.Unsubscribe()
+	devents := make(chan DropTxsEvent, testTxPoolConfig.AccountQueue+5)
+	dsub := pool.dropTxFeed.Subscribe(devents)
+	defer dsub.Unsubscribe()
 
 	// Create a test account to add transactions with
 	key, _ := crypto.GenerateKey()
@@ -1604,6 +1713,9 @@ func TestTransactionReplacement(t *testing.T) {
 	if err := validateEvents(events, 2); err != nil {
 		t.Fatalf("cheap replacement event firing failed: %v", err)
 	}
+	if err := validateDroppedEvents(revents, 1, devents, 4); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
+	}
 
 	if err := pool.addRemoteSync(pricedTransaction(0, 100000, big.NewInt(price), key)); err != nil {
 		t.Fatalf("failed to add original proper pending transaction: %v", err)
@@ -1616,6 +1728,9 @@ func TestTransactionReplacement(t *testing.T) {
 	}
 	if err := validateEvents(events, 2); err != nil {
 		t.Fatalf("proper replacement event firing failed: %v", err)
+	}
+	if err := validateDroppedEvents(revents, 1, devents, 2); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
 	}
 
 	// Add queued transactions, ensuring the minimum price bump is enforced for replacement (for ultra low prices too)
@@ -1641,6 +1756,9 @@ func TestTransactionReplacement(t *testing.T) {
 
 	if err := validateEvents(events, 0); err != nil {
 		t.Fatalf("queued replacement event firing failed: %v", err)
+	}
+	if err := validateDroppedEvents(revents, 2, devents, 6); err != nil {
+		t.Errorf("gap-filling drop / reject event firing failed: %v", err)
 	}
 	if err := validateTxPoolInternals(pool); err != nil {
 		t.Fatalf("pool internal state corrupted: %v", err)

--- a/eth/dropped_tx_subscription.go
+++ b/eth/dropped_tx_subscription.go
@@ -1,0 +1,21 @@
+// This file extends the EthAPIBackend with functions for BlockNative's dropped
+// transaction feeds.
+//
+// As this is part of a fork, and not included in core geth, keeping it in a
+// separate file helps protect against potential merge conflicts. If this were
+// ever to be merged into core geth, it should be relocated to ./api_backend.go
+
+package eth
+
+import (
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+func (b *EthAPIBackend) SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) event.Subscription {
+	return b.eth.TxPool().SubscribeDropTxsEvent(ch)
+}
+
+func (b *EthAPIBackend) SubscribeRejectedTxEvent(ch chan<- core.RejectedTxEvent) event.Subscription {
+	return b.eth.TxPool().SubscribeRejectedTxEvent(ch)
+}

--- a/eth/filters/dropped_tx_subscription.go
+++ b/eth/filters/dropped_tx_subscription.go
@@ -15,7 +15,7 @@ type dropNotification struct {
 }
 
 type rejectNotification struct {
-	Tx *types.Transaction
+	Tx *types.Transaction `json:"tx"`
 	Reason string `json:"reason"`
 }
 
@@ -67,7 +67,11 @@ func (api *PublicFilterAPI) RejectedTransactions(ctx context.Context) (*rpc.Subs
 		for {
 			select {
 			case d := <-rejected:
-				notifier.Notify(rpcSub.ID, &rejectNotification{Tx: d.Tx, Reason: d.Reason.Error()})
+				reason := ""
+				if d.Reason != nil {
+					reason = d.Reason.Error()
+				}
+				notifier.Notify(rpcSub.ID, &rejectNotification{Tx: d.Tx, Reason: reason})
 			case <-rpcSub.Err():
 				rejectedSub.Unsubscribe()
 				return

--- a/eth/filters/dropped_tx_subscription.go
+++ b/eth/filters/dropped_tx_subscription.go
@@ -1,0 +1,82 @@
+package filters
+
+import (
+	"context"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/rpc"
+
+)
+
+type dropNotification struct {
+	TxHash common.Hash `json:"txhash"`
+	Reason string `json:"reason"`
+}
+
+type rejectNotification struct {
+	Tx *types.Transaction
+	Reason string `json:"reason"`
+}
+
+// DroppedTransactions send a notification each time a transaction is dropped from the mempool
+func (api *PublicFilterAPI) DroppedTransactions(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		dropped := make(chan core.DropTxsEvent)
+		droppedSub := api.backend.SubscribeDropTxsEvent(dropped)
+
+		for {
+			select {
+			case d := <-dropped:
+				for _, tx := range d.Txs {
+					notifier.Notify(rpcSub.ID, &dropNotification{TxHash: tx.Hash(), Reason: d.Reason})
+				}
+			case <-rpcSub.Err():
+				droppedSub.Unsubscribe()
+				return
+			case <-notifier.Closed():
+				droppedSub.Unsubscribe()
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
+}
+
+// RejectedTransactions send a notification each time a transaction is rejected from entering the mempool
+func (api *PublicFilterAPI) RejectedTransactions(ctx context.Context) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return &rpc.Subscription{}, rpc.ErrNotificationsUnsupported
+	}
+
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		rejected := make(chan core.RejectedTxEvent)
+		rejectedSub := api.backend.SubscribeRejectedTxEvent(rejected)
+
+		for {
+			select {
+			case d := <-rejected:
+				notifier.Notify(rpcSub.ID, &rejectNotification{Tx: d.Tx, Reason: d.Reason.Error()})
+			case <-rpcSub.Err():
+				rejectedSub.Unsubscribe()
+				return
+			case <-notifier.Closed():
+				rejectedSub.Unsubscribe()
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
+}

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -38,6 +38,8 @@ type Backend interface {
 	GetLogs(ctx context.Context, blockHash common.Hash) ([][]*types.Log, error)
 
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
+	SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) event.Subscription
+	SubscribeRejectedTxEvent(ch chan<- core.RejectedTxEvent) event.Subscription
 	SubscribeChainEvent(ch chan<- core.ChainEvent) event.Subscription
 	SubscribeRemovedLogsEvent(ch chan<- core.RemovedLogsEvent) event.Subscription
 	SubscribeLogsEvent(ch chan<- []*types.Log) event.Subscription

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -73,6 +73,8 @@ type Backend interface {
 	Stats() (pending int, queued int)
 	TxPoolContent() (map[common.Address]types.Transactions, map[common.Address]types.Transactions)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription
+	SubscribeRejectedTxEvent(chan<- core.RejectedTxEvent) event.Subscription
+	SubscribeDropTxsEvent(chan<- core.DropTxsEvent) event.Subscription
 
 	// Filter API
 	BloomStatus() (uint64, uint64)

--- a/les/dropped_tx_subscription.go
+++ b/les/dropped_tx_subscription.go
@@ -1,0 +1,31 @@
+// This file extends the LesApiBackend with functions for BlockNative's dropped
+// transaction feeds.
+//
+// As this is part of a fork, and not included in core geth, keeping it in a
+// separate file helps protect against potential merge conflicts. If this were
+// ever to be merged into core geth, it should be relocated to ./api_backend.go
+
+package les
+
+import (
+	"errors"
+	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+type unimplementedSubscription struct{}
+
+func (s *unimplementedSubscription) Unsubscribe() {}
+func (s *unimplementedSubscription) Err() <-chan error {
+	ch := make(chan error, 1)
+	ch <- errors.New("Subscription type not implemented")
+	return ch
+}
+
+func (b *LesApiBackend) SubscribeDropTxsEvent(ch chan<- core.DropTxsEvent) event.Subscription {
+	return &unimplementedSubscription{}
+}
+
+func (b *LesApiBackend) SubscribeRejectedTxEvent(ch chan<- core.RejectedTxEvent) event.Subscription {
+	return &unimplementedSubscription{}
+}


### PR DESCRIPTION
This adds a feed for dropped transactions, and the key scenarios
where transactions can be dropped to the feed as transactions are
dropped.

I'll be reviewing this in more depth to make sure I haven't missed
any scenarios, but this is the first pass.This adds a feed for dropped transactions, and the key scenarios
where transactions can be dropped to the feed as transactions are
dropped.

I'll be reviewing this in more depth to make sure I haven't missed
any scenarios, but this is the first pass.This adds a feed for dropped transactions, and the key scenarios
where transactions can be dropped to the feed as transactions are
dropped.

I'll be reviewing this in more depth to make sure I haven't missed
any scenarios, but this is the first pass.